### PR TITLE
add: shikwasa, clean up pending

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,60 +10,7 @@ export default defineConfig({
   integrations: [
     tailwind(),
     preact(),
-    {
-      name: 'load-shikwasa',
-      hooks: {
-        'astro:config:setup': ({ injectScript, updateConfig }) => {
-          updateConfig({
-            vite: {
-              plugins: [
-                (() => {
-                  const virtualModuleId = 'virtual:shikwasa';
-                  const resolvedVirtualModuleId = '\0' + virtualModuleId;
-
-                  return {
-                    name: 'vite-plugin-shikwasa-init',
-                    async resolveId(id) {
-                      if (id === virtualModuleId) {
-                        return resolvedVirtualModuleId;
-                      }
-                    },
-                    async load(id) {
-                      if (id === resolvedVirtualModuleId) {
-                        return `
-                        import { Player } from 'shikwasa'
-                        export default Player
-                      `;
-                      }
-                    },
-                  };
-                })()
-              ],
-            },
-          });
-          injectScript(
-            'page',
-            `
-            import Player from 'virtual:shikwasa';
-            globalThis.Player = Player;
-            
-            const player = new Player({
-              container: () => document.querySelector('#shikwasa-player-container'),
-              audio: {
-                title: 'Hello World!',
-                artist: 'Shikwasa FM',
-              },
-            })
-            `,
-          );
-          injectScript(
-            'page-ssr',
-            `import 'shikwasa/dist/style.css';`
-          );
-        },
-      }
-    }],
-
+  ],
   vite: {
     plugins: [
       Icons({

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,62 @@ import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 // https://astro.build/config
 export default defineConfig({
   site: 'https://linju.io',
-  integrations: [tailwind(), preact()],
+  integrations: [
+    tailwind(),
+    preact(),
+    {
+      name: 'load-shikwasa',
+      hooks: {
+        'astro:config:setup': ({ injectScript, updateConfig }) => {
+          updateConfig({
+            vite: {
+              plugins: [
+                (() => {
+                  const virtualModuleId = 'virtual:shikwasa';
+                  const resolvedVirtualModuleId = '\0' + virtualModuleId;
+
+                  return {
+                    name: 'vite-plugin-shikwasa-init',
+                    async resolveId(id) {
+                      if (id === virtualModuleId) {
+                        return resolvedVirtualModuleId;
+                      }
+                    },
+                    async load(id) {
+                      if (id === resolvedVirtualModuleId) {
+                        return `
+                        import { Player } from 'shikwasa'
+                        export default Player
+                      `;
+                      }
+                    },
+                  };
+                })()
+              ],
+            },
+          });
+          injectScript(
+            'page',
+            `
+            import Player from 'virtual:shikwasa';
+            globalThis.Player = Player;
+            
+            const player = new Player({
+              container: () => document.querySelector('#shikwasa-player-container'),
+              audio: {
+                title: 'Hello World!',
+                artist: 'Shikwasa FM',
+              },
+            })
+            `,
+          );
+          injectScript(
+            'page-ssr',
+            `import 'shikwasa/dist/style.css';`
+          );
+        },
+      }
+    }],
 
   vite: {
     plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@astrojs/rss": "^3.0.0",
         "astro": "^3.0.6",
         "lxgw-wenkai-webfont": "^1.7.0",
-        "preact": "^10.16.0"
+        "preact": "^10.16.0",
+        "shikwasa": "^2.2.1"
       },
       "devDependencies": {
         "@astrojs/preact": "^3.0.0",
@@ -8087,6 +8088,11 @@
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
       }
+    },
+    "node_modules/shikwasa": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/shikwasa/-/shikwasa-2.2.1.tgz",
+      "integrity": "sha512-+vfp/krbonBDoyyETd5a/NAMobRfmAKUQQ6pWak0nGuY2VxzAiu6XXMFPHbi0DUgfZe8YAV5naZgWElV+icS/Q=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@astrojs/rss": "^3.0.0",
     "astro": "^3.0.6",
     "lxgw-wenkai-webfont": "^1.7.0",
-    "preact": "^10.16.0"
+    "preact": "^10.16.0",
+    "shikwasa": "^2.2.1"
   },
   "devDependencies": {
     "@astrojs/preact": "^3.0.0",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,11 +1,12 @@
 ---
-
+import ShikwasaPlayer from './ShikwasaPlayer'
 ---
 
 <footer
   class='my-20 flex flex-col gap-4 items-center justify-center dark:text-slate-300 text-slate-600'
 >
-  <p class='flex text-2xl items-baseline'>
+  <ShikwasaPlayer client:only='preact' transition:persist />
+  <p class='flex txt-2xl items-baseline'>
     Made by
     <ruby>🧙<rp>(</rp><rt>Papaya</rt><rp>)</rp></ruby> &
     <ruby>🦹<rp>(</rp><rt>S1ngS1ng</rt><rp>)</rp></ruby>

--- a/src/components/ShikwasaPlayer.tsx
+++ b/src/components/ShikwasaPlayer.tsx
@@ -1,5 +1,5 @@
 import { type FunctionComponent } from 'preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { Player } from '../scripts/load-shikwasa'
 import Logo from '../assets/logo.png'
 
@@ -9,10 +9,12 @@ type ShikwasaPlayerProps = {
 }
 
 const ShikwasaPlayer: FunctionComponent<ShikwasaPlayerProps> = ({}) => {
+  const podcast = useRef(null)
+
   useEffect(() => {
     if (sessionStorage.getItem('playerId') === null) {
       globalThis.player = new Player({
-        container: () => document.querySelector('#shikwasa-player-container'),
+        container: () => podcast.current,
         themeColor: '#C084FC',
         audio: {
           title: 'EP1 不完备实测转码工具包 ｜ 最基础的检查点',
@@ -23,14 +25,11 @@ const ShikwasaPlayer: FunctionComponent<ShikwasaPlayerProps> = ({}) => {
       })
       sessionStorage.setItem('playerId', globalThis.player.id)
     } else {
-      globalThis.player.ui.mount(
-        document.querySelector('#shikwasa-player-container'),
-        true
-      )
+      globalThis.player.ui.mount(podcast.current, true)
     }
   }, [])
 
-  return <div id='shikwasa-player-container' class='m-6'></div>
+  return <div ref={podcast} class='m-6'></div>
 }
 
 export default ShikwasaPlayer

--- a/src/components/ShikwasaPlayer.tsx
+++ b/src/components/ShikwasaPlayer.tsx
@@ -1,5 +1,5 @@
 import { type FunctionComponent } from 'preact'
-import { useCallback, useEffect, useState } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { Player } from '../scripts/load-shikwasa'
 import Logo from '../assets/logo.png'
 
@@ -10,19 +10,24 @@ type ShikwasaPlayerProps = {
 
 const ShikwasaPlayer: FunctionComponent<ShikwasaPlayerProps> = ({}) => {
   useEffect(() => {
-    const player = new Player({
-      container: () => document.querySelector('#shikwasa-player-container'),
-      themeColor: '#C084FC',
-      audio: {
-        title: 'EP1 不完备实测转码工具包 ｜ 最基础的检查点',
-        artist: 'Papaya & S1ngS1ng',
-        cover: Logo.src,
-        src: 'https://podcasts.captivate.fm/media/a7ab2c4e-531a-4bad-aa45-09a6c88d3160/Wangshanglinju-EP-1.mp3'
-      }
-    })
-
-    const path = window.location.pathname
-    console.log(path)
+    if (sessionStorage.getItem('playerId') === null) {
+      globalThis.player = new Player({
+        container: () => document.querySelector('#shikwasa-player-container'),
+        themeColor: '#C084FC',
+        audio: {
+          title: 'EP1 不完备实测转码工具包 ｜ 最基础的检查点',
+          artist: 'Papaya & S1ngS1ng',
+          cover: Logo.src,
+          src: 'https://podcasts.captivate.fm/media/a7ab2c4e-531a-4bad-aa45-09a6c88d3160/Wangshanglinju-EP-1.mp3'
+        }
+      })
+      sessionStorage.setItem('playerId', globalThis.player.id)
+    } else {
+      globalThis.player.ui.mount(
+        document.querySelector('#shikwasa-player-container'),
+        true
+      )
+    }
   }, [])
 
   return <div id='shikwasa-player-container' class='m-6'></div>

--- a/src/components/ShikwasaPlayer.tsx
+++ b/src/components/ShikwasaPlayer.tsx
@@ -1,0 +1,31 @@
+import { type FunctionComponent } from 'preact'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import { Player } from '../scripts/load-shikwasa'
+import Logo from '../assets/logo.png'
+
+type ShikwasaPlayerProps = {
+  // Episode: { sourceUrl: string; title: string; chapters?: string[] }
+  // playState? --- not needed if component doesn't reload upon URL change
+}
+
+const ShikwasaPlayer: FunctionComponent<ShikwasaPlayerProps> = ({}) => {
+  useEffect(() => {
+    const player = new Player({
+      container: () => document.querySelector('#shikwasa-player-container'),
+      themeColor: '#C084FC',
+      audio: {
+        title: 'EP1 不完备实测转码工具包 ｜ 最基础的检查点',
+        artist: 'Papaya & S1ngS1ng',
+        cover: Logo.src,
+        src: 'https://podcasts.captivate.fm/media/a7ab2c4e-531a-4bad-aa45-09a6c88d3160/Wangshanglinju-EP-1.mp3'
+      }
+    })
+
+    const path = window.location.pathname
+    console.log(path)
+  }, [])
+
+  return <div id='shikwasa-player-container' class='m-6'></div>
+}
+
+export default ShikwasaPlayer

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -26,8 +26,24 @@ const lang = getLangFromUrl(Astro.url)
       <slot />
     </div>
 
-    <div id='shikwasa-player-container'></div>
+    <div id='shikwasa-player-container' class='m-12'></div>
 
     <Footer />
+
+    <script>
+      import { Player } from '../scripts/load-shikwasa'
+      import Logo from '../assets/logo.png'
+
+      const player = new Player({
+        container: () => document.querySelector('#shikwasa-player-container'),
+        themeColor: '#C084FC',
+        audio: {
+          title: 'EP1 不完备实测转码工具包 ｜ 最基础的检查点',
+          artist: 'Papaya & S1ngS1ng',
+          cover: Logo.src,
+          src: 'https://podcasts.captivate.fm/media/a7ab2c4e-531a-4bad-aa45-09a6c88d3160/Wangshanglinju-EP-1.mp3'
+        }
+      })
+    </script>
   </body>
 </html>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -26,24 +26,6 @@ const lang = getLangFromUrl(Astro.url)
       <slot />
     </div>
 
-    <div id='shikwasa-player-container' class='m-12'></div>
-
     <Footer />
-
-    <script>
-      import { Player } from '../scripts/load-shikwasa'
-      import Logo from '../assets/logo.png'
-
-      const player = new Player({
-        container: () => document.querySelector('#shikwasa-player-container'),
-        themeColor: '#C084FC',
-        audio: {
-          title: 'EP1 不完备实测转码工具包 ｜ 最基础的检查点',
-          artist: 'Papaya & S1ngS1ng',
-          cover: Logo.src,
-          src: 'https://podcasts.captivate.fm/media/a7ab2c4e-531a-4bad-aa45-09a6c88d3160/Wangshanglinju-EP-1.mp3'
-        }
-      })
-    </script>
   </body>
 </html>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -26,6 +26,8 @@ const lang = getLangFromUrl(Astro.url)
       <slot />
     </div>
 
+    <div id='shikwasa-player-container'></div>
+
     <Footer />
   </body>
 </html>

--- a/src/scripts/load-shikwasa.js
+++ b/src/scripts/load-shikwasa.js
@@ -1,0 +1,2 @@
+import 'shikwasa/dist/style.css'
+export { Player } from 'shikwasa'

--- a/src/scripts/load-shikwasa.js
+++ b/src/scripts/load-shikwasa.js
@@ -1,1 +1,3 @@
 export { Player } from 'shikwasa'
+
+sessionStorage.removeItem('playerId')

--- a/src/scripts/load-shikwasa.js
+++ b/src/scripts/load-shikwasa.js
@@ -1,2 +1,1 @@
-import 'shikwasa/dist/style.css'
 export { Player } from 'shikwasa'

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -1,4 +1,5 @@
 @import 'lxgw-wenkai-webfont/style.css';
+@import 'shikwasa/dist/style.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { CollectionEntry } from 'astro:content'
+import type { CollectionEntry } from 'astro:content'
 
 type restFormatPostsProps = {
   filterOutDrafts?: boolean


### PR DESCRIPTION
**DO NOT MERGE**

## In this PR
- Add `scripts/load-shikwasa.js` to re-export `player` from `shikwasa`, which was intended for `Astro` component. Consider remove
- Import `Shikwasa` style in `style/global.css` to make it accessible from all pages
- Implement `ShikwasaPlayer` w/ `Preact`

## Known issue
- When navigating to/from `/podcast`, the `<ShikwasaPlayer>` component will reload

## TODO
1. Remove `scripts/load-shikwasa.js`
2. `ShikwasaPlayerProp` annotation
3. Make `<ShikwasaPlayer>` persistent upon URL change

Closes #2 