### PR TITLE
fix: add trailing slash to fix the url-based highlight issue

### DIFF
--- a/src/components/MenuToggle.tsx
+++ b/src/components/MenuToggle.tsx
@@ -77,10 +77,10 @@ const MenuToggle: FunctionComponent<menuToggleProps> = ({
             </li>
             <li>
               <a
-                href={translatePath('/about')}
+                href={translatePath('/about/')}
                 onClick={handleClick}
                 className={`font-bold text-xl tracking-widest text-slate-600 relative before:absolute before:inset-x-0 before:bottom-0 before:h-2 before:origin-right before:scale-x-0 before:bg-cyan-400 before:transition before:duration-200 hover:before:origin-left hover:before:scale-x-100 dark:text-slate-200 dark:before:bg-purple-400 ${
-                  currentPath === translatePath('/about')
+                  currentPath === translatePath('/about/')
                     ? `before:scale-x-100`
                     : ``
                 }`}
@@ -92,10 +92,10 @@ const MenuToggle: FunctionComponent<menuToggleProps> = ({
             </li>
             <li>
               <a
-                href={translatePath('/podcast')}
+                href={translatePath('/podcast/')}
                 onClick={handleClick}
                 className={`font-bold text-xl tracking-widest text-slate-600 relative before:absolute before:inset-x-0 before:bottom-0 before:h-2 before:origin-right before:scale-x-0 before:bg-cyan-400 before:transition before:duration-200 hover:before:origin-left hover:before:scale-x-100 dark:text-slate-200 dark:before:bg-purple-400 ${
-                  currentPath === translatePath('/podcast')
+                  currentPath === translatePath('/podcast/')
                     ? `before:scale-x-100`
                     : ``
                 }`}

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -15,7 +15,7 @@ const lang = getLangFromUrl(Astro.url)
 const t = useTranslations(lang)
 const translatePath = useTranslatedPath(lang)
 
-const currentPath = new URL(Astro.request.url).pathname
+const currentPath = Astro.url.pathname
 ---
 
 <header class='bg-[#f3f4f5] dark:bg-neutral-700'>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -33,10 +33,10 @@ const currentPath = new URL(Astro.request.url).pathname
     <nav class='hidden md:flex w-auto mt-2 mt-0'>
       <ul class='flex flex-row gap-8'>
         <Link url={translatePath('/')} {currentPath}>{t('nav.home')}</Link>
-        <Link url={translatePath('/about')} {currentPath}>
+        <Link url={translatePath('/about/')} {currentPath}>
           {t('nav.about')}
         </Link>
-        <Link url={translatePath('/podcast')} {currentPath}>
+        <Link url={translatePath('/podcast/')} {currentPath}>
           {t('nav.podcast')}
         </Link>
       </ul>


### PR DESCRIPTION
## Reproduction

### `npm run dev`
<img width="1104" alt="image" src="https://github.com/linju-podcast/website/assets/13592559/7d73a39c-f68a-42fc-baaa-5ce19d9d9abe">

### `npm run build && npm run preview`
<img width="1262" alt="image" src="https://github.com/linju-podcast/website/assets/13592559/c0bcb56c-c350-4cdd-9d60-f528ab7921e1">


## RCA
- The parameter of `translatePath` is missing the trailing slash
- `Astro.url.pathname` is recommended, see: https://github.com/withastro/docs/pull/1033

See also:
- https://github.com/withastro/astro/issues/5630
- https://github.com/withastro/astro/issues/4190

## Result
### Chinese
<img width="1478" alt="image" src="https://github.com/linju-podcast/website/assets/13592559/bb43872b-5ad8-489b-b970-5e1e156a8b5c">

### English
<img width="1492" alt="image" src="https://github.com/linju-podcast/website/assets/13592559/a4078a1e-1870-4ea0-ba4d-1be4e64d9d37">



Closes #13 